### PR TITLE
Update cubecell_board_v2.json

### DIFF
--- a/boards/cubecell_board_v2.json
+++ b/boards/cubecell_board_v2.json
@@ -4,7 +4,7 @@
     "cpu": "cortex-m0plus",
     "extra_flags": "-DCubeCell_Board_V2",
     "f_cpu": "48000000L",
-    "mcu": "asr6501",
+    "mcu": "asr6502",
     "variant": "CubeCell-Board-V2"
   },
   "frameworks": [


### PR DESCRIPTION
As stated in the official product page (https://heltec.org/project/htcc-ab01-v2/), MCU should be asr6502